### PR TITLE
Fix GCE image

### DIFF
--- a/gpu_reliability/platforms/gcp.py
+++ b/gpu_reliability/platforms/gcp.py
@@ -151,7 +151,7 @@ class GCPPlatform(PlatformBase):
 
     def get_image(self) -> compute_v1.Image:
         # List of public operating system (OS) images: https://cloud.google.com/compute/docs/images/os-details
-        newest_image = self.image_client.get_from_family(project="ubuntu-os-cloud", family="ubuntu-2204-lts-arm64")
+        newest_image = self.image_client.get_from_family(project="debian-cloud", family="debian-11")
         return newest_image
 
     def cleanup_resources(self):


### PR DESCRIPTION
Pick a GCE image that will actually boot. The previous code was trying to boot an ARM image on an x86 instance type. The code doesn't test boot times, but we might as well clean this up in case someone eventually does.